### PR TITLE
[fix] version number typo in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.2.2
+## 1.2.3
 
 - Update to NC 18
 - Fix security issues


### PR DESCRIPTION
The newest version `1.2.3` is wrongly titled `1.2.2` in the changelog file. This PR fixes that.

While trying to confirm this I looked at the releases page:https://github.com/PaulLereverend/NextcloudExtract/releases  
To my surprise the releases were all just named "Extract" or something similar instead of the version number, which is just visible as the tag name on the side.  
Is this on purpose? 😄 