### PR TITLE
fixed extraction in case of external storage with session authentication (>=NC21)

### DIFF
--- a/js/extraction.js
+++ b/js/extraction.js
@@ -14,7 +14,7 @@ $(document).ready(function () {
                     var data = {
                         nameOfFile: filename,
                         directory: context.dir,
-                        external: context.fileInfoModel.attributes.mountType == "external" ? 1 : 0,
+                        external: context.fileInfoModel.attributes.mountType.startsWith("external") ? 1 : 0,
                         type: 'zip'
                     };
                     var tr = context.fileList.findFileEl(filename);
@@ -54,7 +54,7 @@ $(document).ready(function () {
                     var data = {
                         nameOfFile: filename,
                         directory: context.dir,
-                        external: context.fileInfoModel.attributes.mountType == "external" ? 1 : 0,
+                        external: context.fileInfoModel.attributes.mountType.startsWith("external") ? 1 : 0,
                         type: 'rar'
                     };
                     var tr = context.fileList.findFileEl(filename);
@@ -97,7 +97,7 @@ $(document).ready(function () {
                         var data = {
                             nameOfFile: filename,
                             directory: context.dir,
-                            external: context.fileInfoModel.attributes.mountType == "external" ? 1 : 0,
+                            external: context.fileInfoModel.attributes.mountType.startsWith("external") ? 1 : 0,
                             type: 'other'
                         };
                         var tr = context.fileList.findFileEl(filename);


### PR DESCRIPTION
starting with nextcloud 21 the mount type for external storage with session authentication changed from "external" to "external-session". This broke this plugin because the external flag was not set anymore.
This PR matches all external storage mount types and extraction works again.