### PR TITLE
Harden archive extraction: zip-slip protection + exit-code error handling

### DIFF
--- a/lib/Service/ExtractionService.php
+++ b/lib/Service/ExtractionService.php
@@ -21,6 +21,90 @@ final class ExtractionService {
 	}
 
 	/**
+	 * Reject absolute paths and any ".." path component. Modern libzip
+	 * blocks traversal in ZipArchive::extractTo, but neither unrar nor
+	 * 7za do — a crafted archive can write outside $extractTo.
+	 */
+	private function isUnsafePath(string $entry): bool {
+		$norm = str_replace('\\', '/', $entry);
+		if ($norm === '' || $norm === '.' || $norm === './') {
+			return false;
+		}
+		if (str_starts_with($norm, '/')) {
+			return true;
+		}
+		return (bool)preg_match('#(^|/)\.\.($|/)#', $norm);
+	}
+
+	/** @return null|array{code: 0, desc: string} */
+	private function rejectUnsafe(string $entry): ?array {
+		if (!$this->isUnsafePath($entry)) {
+			return null;
+		}
+		$this->logger->warning('Refusing archive with unsafe entry: ' . $entry);
+		return [
+			'code' => 0,
+			'desc' => $this->l->t('Archive contains an unsafe path and was not extracted'),
+		];
+	}
+
+	/** Validate every ZIP entry via libzip indices. @return null|array{code: 0, desc: string} */
+	private function assertSafeZip(ZipArchive $zip): ?array {
+		for ($i = 0; $i < $zip->numFiles; $i++) {
+			$name = $zip->getNameIndex($i);
+			if ($name === false) {
+				return ['code' => 0, 'desc' => $this->l->t('Failed to read archive index')];
+			}
+			if ($err = $this->rejectUnsafe($name)) {
+				return $err;
+			}
+		}
+		return null;
+	}
+
+	/** Validate every RAR entry via `unrar lb` (bare list). @return null|array{code: 0, desc: string} */
+	private function assertSafeRarShell(string $file): ?array {
+		$output = [];
+		$return = 0;
+		exec('unrar lb ' . escapeshellarg($file) . ' 2>&1', $output, $return);
+		if ($return !== 0) {
+			$this->logger->error('unrar list failed (rc=' . $return . '): ' . implode("\n", $output));
+			return ['code' => 0, 'desc' => $this->l->t('Failed to inspect RAR contents')];
+		}
+		foreach ($output as $line) {
+			$line = trim($line);
+			if ($line === '') {
+				continue;
+			}
+			if ($err = $this->rejectUnsafe($line)) {
+				return $err;
+			}
+		}
+		return null;
+	}
+
+	/** Validate every entry via `7za l -ba -slt`. @return null|array{code: 0, desc: string} */
+	private function assertSafe7z(string $file): ?array {
+		$output = [];
+		$return = 0;
+		exec('7za l -ba -slt ' . escapeshellarg($file) . ' 2>&1', $output, $return);
+		if ($return !== 0) {
+			$this->logger->error('7za list failed (rc=' . $return . '): ' . implode("\n", $output));
+			return ['code' => 0, 'desc' => $this->l->t('Failed to inspect archive contents')];
+		}
+		foreach ($output as $line) {
+			if (!str_starts_with($line, 'Path = ')) {
+				continue;
+			}
+			$entry = substr($line, 7);
+			if ($err = $this->rejectUnsafe($entry)) {
+				return $err;
+			}
+		}
+		return null;
+	}
+
+	/**
 	 * @return (bool|int|mixed)[]
 	 *
 	 * @psalm-return array{code: 0|1, desc?: string}
@@ -40,6 +124,11 @@ final class ExtractionService {
 			return $response;
 		}
 
+		if ($err = $this->assertSafeZip($zip)) {
+			$zip->close();
+			return $err;
+		}
+
 		$success = $zip->extractTo($extractTo);
 		$zip->close();
 		$response = array_merge($response, ['code' => $success ? 1 : 0]);
@@ -55,6 +144,9 @@ final class ExtractionService {
 		$response = [];
 
 		if (!extension_loaded('rar')) {
+			if ($err = $this->assertSafeRarShell($file)) {
+				return $err;
+			}
 			exec('unrar x ' . escapeshellarg($file) . ' -R ' . escapeshellarg($extractTo) . '/ -o+', $output, $return);
 			if (sizeof($output) <= 4) {
 				$response = array_merge($response, ['code' => 0, 'desc' => $this->l->t('Oops something went wrong. Check that you have rar extension or unrar installed')]);
@@ -63,6 +155,13 @@ final class ExtractionService {
 		} else {
 			$rar_file = rar_open($file);
 			$list = rar_list($rar_file);
+			// Pre-validate every entry before extracting any of them.
+			foreach ($list as $archive_file) {
+				if ($err = $this->rejectUnsafe($archive_file->getName())) {
+					rar_close($rar_file);
+					return $err;
+				}
+			}
 			foreach ($list as $archive_file) {
 				$entry = rar_entry_get($rar_file, $archive_file->getName());
 				$entry->extract($extractTo);
@@ -81,6 +180,10 @@ final class ExtractionService {
 	 */
 	public function extractOther(string $file, string $extractTo): array {
 		$response = [];
+
+		if ($err = $this->assertSafe7z($file)) {
+			return $err;
+		}
 
 		exec('7za -y x ' . escapeshellarg($file) . ' -o' . escapeshellarg($extractTo), $output, $return);
 

--- a/lib/Service/ExtractionService.php
+++ b/lib/Service/ExtractionService.php
@@ -147,9 +147,12 @@ final class ExtractionService {
 			if ($err = $this->assertSafeRarShell($file)) {
 				return $err;
 			}
-			exec('unrar x ' . escapeshellarg($file) . ' -R ' . escapeshellarg($extractTo) . '/ -o+', $output, $return);
-			if (sizeof($output) <= 4) {
-				$response = array_merge($response, ['code' => 0, 'desc' => $this->l->t('Oops something went wrong. Check that you have rar extension or unrar installed')]);
+			$output = [];
+			$return = 0;
+			exec('unrar x ' . escapeshellarg($file) . ' -R ' . escapeshellarg($extractTo) . '/ -o+ 2>&1', $output, $return);
+			if ($return !== 0) {
+				$this->logger->error('unrar extract failed (rc=' . $return . '): ' . implode("\n", $output));
+				$response = array_merge($response, ['code' => 0, 'desc' => $this->l->t('Failed to extract RAR archive (is the rar extension or unrar installed?)')]);
 				return $response;
 			}
 		} else {
@@ -185,11 +188,13 @@ final class ExtractionService {
 			return $err;
 		}
 
-		exec('7za -y x ' . escapeshellarg($file) . ' -o' . escapeshellarg($extractTo), $output, $return);
+		$output = [];
+		$return = 0;
+		exec('7za -y x ' . escapeshellarg($file) . ' -o' . escapeshellarg($extractTo) . ' 2>&1', $output, $return);
 
-		if (sizeof($output) <= 5) {
-			$response = array_merge($response, ['code' => 0, 'desc' => $this->l->t('Oops something went wrong.')]);
-			$this->logger->error('Is 7-Zip installed? Output: ' . print_r($output, true));
+		if ($return !== 0) {
+			$this->logger->error('7za extract failed (rc=' . $return . '): ' . implode("\n", $output));
+			$response = array_merge($response, ['code' => 0, 'desc' => $this->l->t('Failed to extract archive (is 7-Zip installed?)')]);
 			return $response;
 		}
 		$response = array_merge($response, ['code' => 1]);


### PR DESCRIPTION
## Summary

Two small, independent fixes to `ExtractionService.php`:

1. **Reject archive entries whose paths would escape the destination.** Modern libzip already blocks traversal in `ZipArchive::extractTo`, but the `unrar` and `7za` codepaths blindly trust archive entry paths. A crafted archive with an entry named e.g. `../../etc/something` would write outside `$extractTo`. The first commit adds a per-format pre-extraction listing pass (libzip indices for ZIP, `unrar lb` for RAR, `7za l -ba -slt` for the rest) and refuses to extract anything if an entry has a leading `/` or any `..` path component.

2. **Use real exit codes to detect tool failure** instead of `sizeof($output) <= 4`/`<= 5`. The current heuristic can both miss real failures (verbose error output makes a failed extract look successful) and produce false positives (a successful extract of a small archive looks like a failure). The second commit checks `$return`, captures stderr into the output, and logs the full tool output on failure.

The commits are independent and can be cherry-picked separately.

## Security review

A full security review of this branch (codebase walk, `composer audit`, `npm audit`, psalm, and a targeted look at the patched diff) came back clean — no XSS / SSRF / CSRF / command-injection findings and no static-analysis or dependency-audit regressions. Full report in the first comment on this PR.

## Test plan

- [ ] Manual: ZIP containing an entry named `../escape.txt` is refused with "Archive contains an unsafe path..." (verified locally via the OCS `execute` route).
- [ ] Manual: tar containing `../escape.txt` (extractOther codepath via `7za`) is refused.
- [ ] Manual: benign nested archives extract as before.
- [ ] Manual: small valid archive no longer trips the `sizeof <= N` false-failure path.
- [ ] CI / psalm: lint clean against existing baseline.

## Notes

- No new dependencies. `unrar lb` and `7za l -ba -slt` are part of the same `unrar` / `p7zip-full` packages the existing extraction commands already require.
- The `unrar lb` call assumes proprietary `unrar` (matching the existing `unrar x ... -R ... -o+` syntax). If you'd like the RAR path to also work on `unrar-free`, happy to add a second listing strategy.
- No behavior change for the happy path on any format.
- I'm a downstream user, not a regular contributor — happy to refine in any direction the maintainers prefer (split smaller, larger test plan, doc updates, etc.).
